### PR TITLE
Add ubuntu-noble base image and Roswell SBCL Common Lisp images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
-.PHONY: concourse go
+.PHONY: concourse concourse-noble go cl-jammy cl-noble
 
 concourse:
 	docker build -t genesiscommunity/concourse:latest concourse/latest/
 
+concourse-noble:
+	docker build -t genesiscommunity/concourse:ubuntu-noble concourse/ubuntu-noble/
+
 go:
 	docker build -t genesiscommunity/concourse-go:1.20 concourse-go/1.20/
 
+cl-jammy:
+	cd concourse-cl/jammy && $(MAKE) docker
+
+cl-noble: concourse-noble
+	cd concourse-cl/noble && $(MAKE) docker

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
-.PHONY: concourse concourse-noble go cl-jammy cl-noble
+PLATFORM := linux/amd64
+
+.PHONY: concourse concourse-jammy concourse-noble go cl-jammy cl-noble
 
 concourse:
-	docker build -t genesiscommunity/concourse:latest concourse/latest/
+	docker build --platform $(PLATFORM) -t genesiscommunity/concourse:latest concourse/latest/
+
+concourse-jammy:
+	docker build --platform $(PLATFORM) -t genesiscommunity/concourse:ubuntu-jammy concourse/ubuntu-jammy/
 
 concourse-noble:
-	docker build -t genesiscommunity/concourse:ubuntu-noble concourse/ubuntu-noble/
+	docker build --platform $(PLATFORM) -t genesiscommunity/concourse:ubuntu-noble concourse/ubuntu-noble/
 
 go:
-	docker build -t genesiscommunity/concourse-go:1.20 concourse-go/1.20/
+	docker build --platform $(PLATFORM) -t genesiscommunity/concourse-go:1.20 concourse-go/1.20/
 
-cl-jammy:
-	cd concourse-cl/jammy && $(MAKE) docker
+cl-jammy: concourse-jammy
+	cd concourse-cl/jammy && $(MAKE) PLATFORM="$(PLATFORM)" docker
 
 cl-noble: concourse-noble
-	cd concourse-cl/noble && $(MAKE) docker
+	cd concourse-cl/noble && $(MAKE) PLATFORM="$(PLATFORM)" docker

--- a/concourse-cl/jammy/Dockerfile
+++ b/concourse-cl/jammy/Dockerfile
@@ -1,10 +1,15 @@
 ARG BASE_IMAGE=genesiscommunity/concourse:ubuntu-jammy
 FROM --platform=linux/amd64 $BASE_IMAGE
 ARG SBCL_VERSION
+ARG SBCL_DIST=roswell
 
 WORKDIR /tmp
-RUN curl -L -o sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2 \
-    https://github.com/roswell/sbcl_bin/releases/download/${SBCL_VERSION}/sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2 && \
+RUN case "${SBCL_DIST}" in \
+      roswell)     url="https://github.com/roswell/sbcl_bin/releases/download/${SBCL_VERSION}/sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2" ;; \
+      sourceforge) url="https://sourceforge.net/projects/sbcl/files/sbcl/${SBCL_VERSION}/sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2/download" ;; \
+      *)           echo "Unknown SBCL_DIST: ${SBCL_DIST}" >&2 && exit 1 ;; \
+    esac && \
+    curl -L -o sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2 "$url" && \
     tar xjf sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2 && \
     cd sbcl-${SBCL_VERSION}-x86-64-linux && \
     INSTALL_ROOT=/usr/local sh install.sh && \
@@ -16,10 +21,11 @@ ARG VCS_URL=https://github.com/genesis-community/concourse-dockerfiles
 ARG VCS_REF
 LABEL org.opencontainers.image.authors="Norman Abramovitz, James Hunt" \
       org.opencontainers.image.title="Common Lisp Build Container" \
-      org.opencontainers.image.version="" \
+      org.opencontainers.image.version=$SBCL_VERSION \
       org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.source=$VCS_URL \
       org.opencontainers.image.revision=$VCS_REF \
       org.opencontainers.image.base.name=$BASE_IMAGE
 
+WORKDIR /u
 CMD ["sbcl", "--script", "/u/boot.lisp"]

--- a/concourse-cl/jammy/Dockerfile
+++ b/concourse-cl/jammy/Dockerfile
@@ -16,6 +16,14 @@ RUN case "${SBCL_DIST}" in \
     cd /tmp && \
     rm -rf sbcl-${SBCL_VERSION}-x86-64-linux*
 
+# Install Quicklisp
+RUN curl -L -o /tmp/quicklisp.lisp https://beta.quicklisp.org/quicklisp.lisp && \
+    sbcl --non-interactive \
+         --load /tmp/quicklisp.lisp \
+         --eval '(quicklisp-quickstart:install)' \
+         --eval '(ql-util:without-prompting (ql:add-to-init-file))' && \
+    rm /tmp/quicklisp.lisp
+
 ARG BUILD_DATE
 ARG VCS_URL=https://github.com/genesis-community/concourse-dockerfiles
 ARG VCS_REF

--- a/concourse-cl/jammy/Makefile
+++ b/concourse-cl/jammy/Makefile
@@ -3,11 +3,13 @@ NAME := concourse-cl
 TAG := ubuntu-jammy
 PLATFORM := linux/amd64
 SBCL_VERSION := 2.6.2
+SBCL_DIST := roswell
 
 
 docker:
 	docker build \
 	   --build-arg SBCL_VERSION="$(SBCL_VERSION)" \
+	   --build-arg SBCL_DIST="$(SBCL_DIST)" \
 	   --build-arg BUILD_DATE="$(shell date -u -Iminutes)" \
 	   --build-arg VCS_URL="$(shell git ls-remote --get-url origin)" \
 	   --build-arg VCS_REF="$(shell git rev-parse --short HEAD)" \

--- a/concourse-cl/jammy/README.md
+++ b/concourse-cl/jammy/README.md
@@ -72,6 +72,27 @@ RUN sbcl --non-interactive \
 CMD ["/app/my-app"]
 ```
 
+## Compatibility Notes
+
+The Roswell SBCL binary is built for broad Linux compatibility. It only
+requires **GLIBC 2.17** or newer, making it safe to run on any modern
+Linux distribution.
+
+Libraries loaded at runtime via CFFI (such as OpenSSL via cl+ssl) use
+`dlopen` and resolve against the shared libraries inside the container.
+Since each image is self-contained, there are no cross-distribution
+glibc or library version issues.
+
+**Important:** A binary compiled with `save-lisp-and-die` inside one
+image (e.g. noble with glibc 2.39) should not be extracted and run on
+an older host (e.g. jammy with glibc 2.35). Always run the binary in
+the same container environment it was built in.
+
+| Image | Ubuntu | glibc | OpenSSL |
+|-------|--------|-------|---------|
+| ubuntu-jammy | 22.04 LTS | 2.35 | 3.0.2 |
+| ubuntu-noble | 24.04 LTS | 2.39 | 3.0.13 |
+
 ## Makefile Variables
 
 | Variable | Default | Description |

--- a/concourse-cl/noble/Dockerfile
+++ b/concourse-cl/noble/Dockerfile
@@ -1,10 +1,15 @@
 ARG BASE_IMAGE=genesiscommunity/concourse:ubuntu-noble
 FROM --platform=linux/amd64 $BASE_IMAGE
 ARG SBCL_VERSION
+ARG SBCL_DIST=roswell
 
 WORKDIR /tmp
-RUN curl -L -o sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2 \
-    https://github.com/roswell/sbcl_bin/releases/download/${SBCL_VERSION}/sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2 && \
+RUN case "${SBCL_DIST}" in \
+      roswell)     url="https://github.com/roswell/sbcl_bin/releases/download/${SBCL_VERSION}/sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2" ;; \
+      sourceforge) url="https://sourceforge.net/projects/sbcl/files/sbcl/${SBCL_VERSION}/sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2/download" ;; \
+      *)           echo "Unknown SBCL_DIST: ${SBCL_DIST}" >&2 && exit 1 ;; \
+    esac && \
+    curl -L -o sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2 "$url" && \
     tar xjf sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2 && \
     cd sbcl-${SBCL_VERSION}-x86-64-linux && \
     INSTALL_ROOT=/usr/local sh install.sh && \
@@ -16,10 +21,11 @@ ARG VCS_URL=https://github.com/genesis-community/concourse-dockerfiles
 ARG VCS_REF
 LABEL org.opencontainers.image.authors="Norman Abramovitz, James Hunt" \
       org.opencontainers.image.title="Common Lisp Build Container" \
-      org.opencontainers.image.version="" \
+      org.opencontainers.image.version=$SBCL_VERSION \
       org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.source=$VCS_URL \
       org.opencontainers.image.revision=$VCS_REF \
       org.opencontainers.image.base.name=$BASE_IMAGE
 
+WORKDIR /u
 CMD ["sbcl", "--script", "/u/boot.lisp"]

--- a/concourse-cl/noble/Dockerfile
+++ b/concourse-cl/noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=genesiscommunity/concourse:ubuntu-jammy
+ARG BASE_IMAGE=genesiscommunity/concourse:ubuntu-noble
 FROM --platform=linux/amd64 $BASE_IMAGE
 ARG SBCL_VERSION
 

--- a/concourse-cl/noble/Dockerfile
+++ b/concourse-cl/noble/Dockerfile
@@ -16,6 +16,14 @@ RUN case "${SBCL_DIST}" in \
     cd /tmp && \
     rm -rf sbcl-${SBCL_VERSION}-x86-64-linux*
 
+# Install Quicklisp
+RUN curl -L -o /tmp/quicklisp.lisp https://beta.quicklisp.org/quicklisp.lisp && \
+    sbcl --non-interactive \
+         --load /tmp/quicklisp.lisp \
+         --eval '(quicklisp-quickstart:install)' \
+         --eval '(ql-util:without-prompting (ql:add-to-init-file))' && \
+    rm /tmp/quicklisp.lisp
+
 ARG BUILD_DATE
 ARG VCS_URL=https://github.com/genesis-community/concourse-dockerfiles
 ARG VCS_REF

--- a/concourse-cl/noble/Makefile
+++ b/concourse-cl/noble/Makefile
@@ -1,6 +1,6 @@
 ORG := genesiscommunity
 NAME := concourse-cl
-TAG := ubuntu-jammy
+TAG := ubuntu-noble
 PLATFORM := linux/amd64
 SBCL_VERSION := 2.6.2
 

--- a/concourse-cl/noble/Makefile
+++ b/concourse-cl/noble/Makefile
@@ -3,11 +3,13 @@ NAME := concourse-cl
 TAG := ubuntu-noble
 PLATFORM := linux/amd64
 SBCL_VERSION := 2.6.2
+SBCL_DIST := roswell
 
 
 docker:
 	docker build \
 	   --build-arg SBCL_VERSION="$(SBCL_VERSION)" \
+	   --build-arg SBCL_DIST="$(SBCL_DIST)" \
 	   --build-arg BUILD_DATE="$(shell date -u -Iminutes)" \
 	   --build-arg VCS_URL="$(shell git ls-remote --get-url origin)" \
 	   --build-arg VCS_REF="$(shell git rev-parse --short HEAD)" \

--- a/concourse-cl/noble/README.md
+++ b/concourse-cl/noble/README.md
@@ -1,4 +1,4 @@
-genesiscommunity/concourse-cl:ubuntu-jammy
+genesiscommunity/concourse-cl:ubuntu-noble
 ===========================================
 
 Task Image for running Concourse Pipelines - Common Lisp
@@ -25,7 +25,7 @@ Run a Lisp script:
 ```bash
 docker run -it \
        -v ~/code/my-lisp-code-directory:/u \
-       genesiscommunity/concourse-cl:ubuntu-jammy
+       genesiscommunity/concourse-cl:ubuntu-noble
 ```
 
 By default the image executes `/u/boot.lisp`.
@@ -36,22 +36,22 @@ From the repository root:
 
 ```bash
 # Build the base image and CL image
-make cl-jammy
+make cl-noble
 
 # Build with a specific SBCL version
-make cl-jammy SBCL_VERSION=2.6.2
+make cl-noble SBCL_VERSION=2.6.2
 
 # Switch SBCL distribution source (roswell or sourceforge)
-make cl-jammy SBCL_DIST=sourceforge
+make cl-noble SBCL_DIST=sourceforge
 
 # Override platform (default: linux/amd64)
-make cl-jammy PLATFORM=linux/arm64
+make cl-noble PLATFORM=linux/arm64
 ```
 
-Or build from the `concourse-cl/jammy/` directory:
+Or build from the `concourse-cl/noble/` directory:
 
 ```bash
-cd concourse-cl/jammy
+cd concourse-cl/noble
 make docker                          # build the image
 make test                            # run hello-world test
 make publish                         # push to Docker Hub
@@ -62,7 +62,7 @@ make publish                         # push to Docker Hub
 Example Dockerfile for building a Common Lisp project:
 
 ```dockerfile
-FROM genesiscommunity/concourse-cl:ubuntu-jammy
+FROM genesiscommunity/concourse-cl:ubuntu-noble
 WORKDIR /app
 COPY . .
 RUN sbcl --non-interactive \

--- a/concourse-cl/noble/README.md
+++ b/concourse-cl/noble/README.md
@@ -72,6 +72,27 @@ RUN sbcl --non-interactive \
 CMD ["/app/my-app"]
 ```
 
+## Compatibility Notes
+
+The Roswell SBCL binary is built for broad Linux compatibility. It only
+requires **GLIBC 2.17** or newer, making it safe to run on any modern
+Linux distribution.
+
+Libraries loaded at runtime via CFFI (such as OpenSSL via cl+ssl) use
+`dlopen` and resolve against the shared libraries inside the container.
+Since each image is self-contained, there are no cross-distribution
+glibc or library version issues.
+
+**Important:** A binary compiled with `save-lisp-and-die` inside one
+image (e.g. noble with glibc 2.39) should not be extracted and run on
+an older host (e.g. jammy with glibc 2.35). Always run the binary in
+the same container environment it was built in.
+
+| Image | Ubuntu | glibc | OpenSSL |
+|-------|--------|-------|---------|
+| ubuntu-jammy | 22.04 LTS | 2.35 | 3.0.2 |
+| ubuntu-noble | 24.04 LTS | 2.39 | 3.0.13 |
+
 ## Makefile Variables
 
 | Variable | Default | Description |

--- a/concourse-cl/noble/tests/hello-world
+++ b/concourse-cl/noble/tests/hello-world
@@ -1,0 +1,1 @@
+(format t "Hello, World!~%")

--- a/concourse/ubuntu-noble/Dockerfile
+++ b/concourse/ubuntu-noble/Dockerfile
@@ -1,0 +1,159 @@
+FROM --platform=linux/amd64 ubuntu:noble
+
+ENV COLUMNS=80
+
+ENV BOSH_VERSION=${BOSH_VERSION:-7.2.3}
+ENV CERTSTRAP_VERSION=${CERTSTRAP_VERSION:-1.3.0}
+ENV CF_7_VERSION=${CF_7_VERSION:-7.6.0}
+ENV CF_8_VERSION=${CF_8_VERSION:-8.6.1}
+ENV CREDHUB_VERSION=${CREDHUB_VERSION:-2.9.18}
+ENV GENESIS_VERSION=${GENESIS_VERSION:-3.0.9}
+ENV GOTCHA_VERSION=${GOTCHA_VERSION:-0.2.0}
+ENV HUGO_VERSION=${HUGO_VERSION:-0.36}
+ENV JQ_VERSION=${JQ_VERSION:-1.6}
+ENV SAFE_VERSION=${SAFE_VERSION:-1.9.0}
+ENV SHIELD_VERSION=${SHIELD_VERSION:-8.8.4}
+ENV SPRUCE_VERSION=${SPRUCE_VERSION:-1.30.2}
+ENV VAULT_VERSION=${VAULT_VERSION:-1.14.0}
+ENV HUB_VERSION=${HUB_VERSION:-2.14.2}
+ENV S3_VERSION=${S3_VERSION:-0.3.2}
+
+# COLUMNS var added to work around bosh cli needing a terminal size specified
+
+# base packages
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+      && apt-get install -yy \
+                   autoconf \
+                   build-essential \
+                   bzip2 \
+                   curl \
+                   file \
+                   gcc \
+                   git \
+                   gnupg \
+                   libc6 \
+                   libreadline-dev \
+                   libsqlite3-dev \
+                   libssl-dev \
+                   libtool \
+                   libxml2-dev \
+                   libxslt1-dev \
+                   libyaml-dev \
+                   lsof \
+                   openssl \
+                   ruby \
+                   ruby-dev \
+                   sipcalc \
+                   sqlite3 \
+                   tig \
+                   unzip \
+                   vim \
+                   vim-common \
+                   wget \
+                   zlib1g \
+                   zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+## Vault
+RUN curl -sOL "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" \
+    && unzip vault_${VAULT_VERSION}_linux_amd64.zip \
+    && mv vault /usr/bin/vault \
+    && chmod 0755 /usr/bin/vault \
+    && rm vault_${VAULT_VERSION}_linux_amd64.zip
+
+## safe
+RUN curl -sOL "https://github.com/cloudfoundry-community/safe/releases/download/v${SAFE_VERSION}/safe-${SAFE_VERSION}-linux-amd64" \
+    && mv safe-${SAFE_VERSION}-linux-amd64 /usr/bin/safe \
+    && chmod 0755 /usr/bin/safe
+
+## Spruce
+RUN curl -sOL "https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64" \
+    && mv spruce-linux-amd64 /usr/bin/spruce \
+    && chmod 0755 /usr/bin/spruce
+
+## bosh
+RUN curl -sOL "https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_VERSION}/bosh-cli-${BOSH_VERSION}-linux-amd64" \
+    && mv bosh-cli-${BOSH_VERSION}-linux-amd64 /usr/bin/bosh \
+    && chmod 0755 /usr/bin/bosh
+
+## credhub-cli
+RUN curl -sOL "https://github.com/cloudfoundry/credhub-cli/releases/download/${CREDHUB_VERSION}/credhub-linux-${CREDHUB_VERSION}.tgz" \
+    && tar zxvf credhub-linux-${CREDHUB_VERSION}.tgz \
+    && mv credhub /usr/bin/credhub \
+    && chmod 0755 /usr/bin/credhub \
+    && rm credhub-linux-${CREDHUB_VERSION}.tgz
+
+## genesis
+RUN curl -sOL "https://github.com/genesis-community/genesis/releases/download/v${GENESIS_VERSION}/genesis" \
+    && mv genesis /usr/bin/genesis \
+    && chmod 0755 /usr/bin/genesis
+
+## certstrap
+RUN curl -sOL "https://github.com/square/certstrap/releases/download/v${CERTSTRAP_VERSION}/certstrap-linux-amd64" \
+    && mv certstrap-linux-amd64 /usr/bin/certstrap \
+    && chmod 0755 /usr/bin/certstrap
+
+## gotcha
+RUN curl -sOL "https://github.com/starkandwayne/gotcha/releases/download/v${GOTCHA_VERSION}/gotcha-linux-amd64" \
+    && mv gotcha-linux-amd64 /usr/bin/gotcha \
+    && chmod 0755 /usr/bin/gotcha
+
+## shield
+RUN curl -fsSLo shield "https://github.com/shieldproject/shield/releases/download/v${SHIELD_VERSION}/shield-linux-amd64" \
+    && mv shield /usr/bin/shield \
+    && chmod 0755 /usr/bin/shield
+
+# git-lfs
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -yy git-lfs && \
+    git lfs install
+
+# hugo
+RUN curl -L >hugo.tar.gz "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz" \
+    && tar -xzvf hugo.tar.gz -C /usr/bin \
+    && rm hugo.tar.gz
+
+# jq
+RUN curl -sOL "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" \
+    && mv jq-linux64 /usr/bin/jq \
+    && chmod 0755 /usr/bin/jq
+
+# kubectl
+RUN v=$(curl -L -s https://dl.k8s.io/release/stable.txt) ; \
+    curl -LO "https://dl.k8s.io/release/${v}/bin/linux/amd64/kubectl" \
+    && mv kubectl /usr/bin/kubectl \
+    && chmod 0755 /usr/bin/kubectl
+
+# hub
+RUN curl -sOL "https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz" \
+    && tar -xvzf hub-linux-amd64-${HUB_VERSION}.tgz \
+    && mv hub-linux-amd64-${HUB_VERSION}/bin/hub /usr/bin/hub \
+    && chmod 0755 /usr/bin/hub \
+    && rm hub-linux-amd64-${HUB_VERSION}.tgz
+
+# cf v7
+RUN curl -sL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_7_VERSION}&source=github-rel" -o cf-cli_${CF_7_VERSION}_linux_x86-64.tgz  \
+    && tar -xvzf cf-cli_${CF_7_VERSION}_linux_x86-64.tgz \
+    && mv cf7 /usr/bin/cf7 \
+    && chmod 0755 /usr/bin/cf7 \
+    && rm cf-cli_${CF_7_VERSION}_linux_x86-64.tgz
+
+# cf v8
+RUN curl -sL "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_8_VERSION}&source=github-rel" -o cf-cli_${CF_8_VERSION}_linux_x86-64.tgz \
+    && tar -xvzf cf-cli_${CF_8_VERSION}_linux_x86-64.tgz \
+    && mv cf8 /usr/bin/cf8 \
+    && mv cf /usr/bin/cf \
+    && chmod 0755 /usr/bin/cf8 \
+    && rm cf-cli_${CF_8_VERSION}_linux_x86-64.tgz
+
+# aws cli
+RUN curl -sL "https://github.com/jhunt/s3/releases/download/v${S3_VERSION}/s3-linux-amd64" -o "s3" \
+    && mv s3 /usr/bin/s3 \
+    && chmod 0755 /usr/bin/s3
+
+# uaac
+RUN gem install cf-uaac -v 4.2.0 --no-document
+
+# Add a user for running things as non-superuser
+RUN useradd -ms /bin/bash worker


### PR DESCRIPTION
## Summary

- Add `concourse/ubuntu-noble` base image (Ubuntu 24.04 LTS)
- Add `concourse-cl/jammy` and `concourse-cl/noble` Common Lisp images using Roswell SBCL 2.6.2
- Include Quicklisp (auto-loaded on startup) and ASDF in CL images
- Add `SBCL_DIST` build arg to switch between Roswell and SourceForge SBCL sources
- Add `PLATFORM` variable to root Makefile (default: `linux/amd64`)
- Add `concourse-jammy` base image build target and proper dependencies
- Bump genesis to 3.0.9

## Changes

**New files:**
- `concourse/ubuntu-noble/Dockerfile` — Noble base image
- `concourse-cl/jammy/` — Dockerfile, Makefile, README, tests
- `concourse-cl/noble/` — Dockerfile, Makefile, README, tests

**Modified files:**
- `Makefile` — Added `PLATFORM` variable, `concourse-jammy`/`concourse-noble` targets, `cl-jammy`/`cl-noble` targets with proper base image dependencies

**Key design decisions:**
- Roswell SBCL binary requires only GLIBC 2.17+, ensuring broad compatibility
- `SBCL_DIST` allows switching between `roswell` (default) and `sourceforge` sources
- Quicklisp installed non-interactively and added to `.sbclrc` for auto-loading
- CFFI libraries (e.g. OpenSSL via cl+ssl) loaded at runtime via `dlopen`, no cross-image glibc issues

## Test plan

- [x] Built and tested `concourse-cl:ubuntu-jammy` (hello-world)
- [x] Built and tested `concourse-cl:ubuntu-noble` (hello-world)
- [x] Verified SBCL 2.6.2, ASDF 3.3.1, Quicklisp auto-load on both images
- [x] Built shout project successfully on both jammy and noble base images
- [x] Verified glibc/OpenSSL compatibility across both images